### PR TITLE
Add augmentations service with Albumentations presets and update AI library registry

### DIFF
--- a/MAGE/api/common.py
+++ b/MAGE/api/common.py
@@ -9,7 +9,9 @@ from typing import Final
 
 LIBRARIES_BY_CATEGORY: Final[dict[str, dict[str, str]]] = {
     "AI": {
+        "albumentations": "albumentations",
         "keras": "keras",
+        "pycaret": "pycaret",
         "segmentation-models-pytorch": "segmentation_models_pytorch",
         "tensorflow": "tensorflow",
         "timm": "timm",

--- a/MAGE/api/main.py
+++ b/MAGE/api/main.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 from fastapi import FastAPI
 from fastmcp import FastMCP
 
+from MAGE.api.services.augmentations import augmentation_presets, validate_preset
+from MAGE.api.services.augmentations import service_app as augmentations_service
 from MAGE.api.services.encoders import list_encoders
 from MAGE.api.services.encoders import service_app as encoders_service
 from MAGE.api.services.libraries import libraries
@@ -46,6 +48,18 @@ async def read_root() -> dict[str, str]:
 
 # Backward-compatible routes served directly by the gateway.
 api.add_api_route("/libraries", libraries, methods=["GET"], tags=["libraries"])
+api.add_api_route(
+    "/augmentations",
+    augmentation_presets,
+    methods=["GET"],
+    tags=["augmentations"],
+)
+api.add_api_route(
+    "/augmentations/{preset_name}/validate",
+    validate_preset,
+    methods=["GET"],
+    tags=["augmentations"],
+)
 api.add_api_route("/encoders", list_encoders, methods=["GET"], tags=["encoders"])
 api.add_api_route("/model", model_list, methods=["GET"], tags=["models"])
 api.add_api_route(
@@ -76,6 +90,7 @@ api.add_api_route(
 
 # Microservice mounts (service-style boundaries under dedicated prefixes).
 api.mount("/services/libraries", libraries_service)
+api.mount("/services/augmentations", augmentations_service)
 api.mount("/services/encoders", encoders_service)
 api.mount("/services/models", models_service)
 api.mount("/services/modules", modules_service)

--- a/MAGE/api/services/augmentations.py
+++ b/MAGE/api/services/augmentations.py
@@ -1,0 +1,114 @@
+# Copyright (C) 2026 AIMER contributors.
+
+"""Augmentations service: expose Albumentations availability and presets."""
+
+from __future__ import annotations
+
+from importlib import import_module
+
+from fastapi import APIRouter, FastAPI, HTTPException
+
+router = APIRouter(tags=["augmentations"])
+
+
+@router.get("/health")
+async def healthcheck() -> dict[str, str]:
+    """
+    Service-local health-check endpoint.
+
+    Returns:
+        dict[str, str]: Simple status payload for this microservice.
+
+    """
+    return {"augmentations_service": "UP"}
+
+
+@router.get("/augmentations")
+async def augmentation_presets() -> dict[str, object]:
+    """
+    Return baseline augmentation presets suitable for image datasets.
+
+    Returns:
+        dict[str, object]: Albumentations version plus classification and
+            segmentation-oriented preset recipes.
+
+    Raises:
+        HTTPException: If Albumentations is unavailable.
+
+    """
+    try:
+        alb = import_module("albumentations")
+    except Exception as exc:
+        raise HTTPException(
+            status_code=503,
+            detail="albumentations is unavailable",
+        ) from exc
+
+    alb_version = getattr(alb, "__version__", None)
+    return {
+        "library": "albumentations",
+        "version": alb_version,
+        "presets": {
+            "classification_basic": [
+                "HorizontalFlip(p=0.5)",
+                (
+                    "ShiftScaleRotate(shift_limit=0.05, scale_limit=0.1, "
+                    "rotate_limit=15, p=0.5)"
+                ),
+                "RandomBrightnessContrast(p=0.3)",
+                "Normalize()",
+            ],
+            "segmentation_basic": [
+                "HorizontalFlip(p=0.5)",
+                "VerticalFlip(p=0.2)",
+                "RandomResizedCrop(height=256, width=256, scale=(0.7, 1.0), p=0.5)",
+                "Normalize()",
+            ],
+        },
+    }
+
+
+@router.get("/augmentations/{preset_name}/validate")
+async def validate_preset(preset_name: str) -> dict[str, object]:
+    """
+    Validate that a preset uses transforms available in Albumentations.
+
+    Args:
+        preset_name: Name of the preset to validate.
+
+    Returns:
+        dict[str, object]: Validation report including missing transform names.
+
+    Raises:
+        HTTPException: If Albumentations is unavailable or preset is unknown.
+
+    """
+    payload = await augmentation_presets()
+    presets = payload["presets"]
+    if not isinstance(presets, dict) or preset_name not in presets:
+        raise HTTPException(status_code=404, detail="unknown augmentation preset")
+
+    try:
+        alb = import_module("albumentations")
+    except Exception as exc:
+        raise HTTPException(
+            status_code=503,
+            detail="albumentations is unavailable",
+        ) from exc
+
+    steps = presets[preset_name]
+    if not isinstance(steps, list):
+        raise HTTPException(status_code=500, detail="invalid preset structure")
+
+    transform_names = [step.split("(")[0] for step in steps]
+    missing = [name for name in transform_names if getattr(alb, name, None) is None]
+    return {
+        "preset": preset_name,
+        "transforms": transform_names,
+        "missing_transforms": missing,
+        "is_valid": len(missing) == 0,
+    }
+
+
+service_app = FastAPI(title="Augmentations Service")
+service_app.include_router(router)

--- a/MAGE/pyproject.toml
+++ b/MAGE/pyproject.toml
@@ -6,6 +6,7 @@ dependencies = [
   "fastapi[standard-no-fastapi-cloud-cli]==0.136.1",
   "fastmcp==3.2.4",
   "keras==3.14.0",
+  "albumentations>=1.4.0",
   "segmentation-models-pytorch==0.5.0",
 
   # macOS (Intel + Apple Silicon)
@@ -21,5 +22,6 @@ dependencies = [
   "torch>=2.11.0",
   "torchvision>=0.26.0",
   "tqdm>=4.67.3",
+  "pycaret==4.0.0a8",
   "granian==2.7.4",
 ]

--- a/MAGE/tests/test_library_registry.py
+++ b/MAGE/tests/test_library_registry.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2026 AIMER contributors.
+
+"""Checks for AI library registry consistency."""
+
+from MAGE.api.common import LIBRARIES_BY_CATEGORY
+
+
+def test_ai_registry_includes_augmentation_and_modeling_libs() -> None:
+    """
+    AI registry should track albumentations, pycaret, timm and SMP.
+
+    Raises:
+        AssertionError: If one expected AI library mapping is missing or wrong.
+
+    """
+    ai = LIBRARIES_BY_CATEGORY["AI"]
+    if ai["albumentations"] != "albumentations":
+        msg = "albumentations should map to albumentations module"
+        raise AssertionError(msg)
+    if ai["pycaret"] != "pycaret":
+        msg = "pycaret should map to pycaret module"
+        raise AssertionError(msg)
+    if ai["timm"] != "timm":
+        msg = "timm should map to timm module"
+        raise AssertionError(msg)
+    if ai["segmentation-models-pytorch"] != "segmentation_models_pytorch":
+        msg = "SMP package should map to segmentation_models_pytorch module"
+        raise AssertionError(msg)

--- a/MAGE/tests/test_main.py
+++ b/MAGE/tests/test_main.py
@@ -68,13 +68,18 @@ class FakeTimm(ModuleType):
         return bool(self._pretrained.get(model_id, False))
 
 
-
-
 class FakeSMPEncoders:
     """Minimal fake of SMP encoders registry."""
 
     @staticmethod
     def get_encoder_names() -> list[str]:
+        """
+        Return deterministic encoder names used by API tests.
+
+        Returns:
+            list[str]: Static list of fake SMP encoder names.
+
+        """
         return ["resnet34", "tu-efficientnet_b0", "tu-convnext_tiny"]
 
 
@@ -82,9 +87,25 @@ class FakeSMP(ModuleType):
     """In-memory stand-in for ``segmentation_models_pytorch``."""
 
     def __init__(self) -> None:
+        """Initialize fake SMP module metadata and encoder registry."""
         super().__init__("segmentation_models_pytorch")
         self.__version__ = "0.0.0"
         self.encoders = FakeSMPEncoders()
+
+
+class FakeAlbumentations(ModuleType):
+    """In-memory stand-in for ``albumentations`` used by API tests."""
+
+    def __init__(self) -> None:
+        """Initialize deterministic fake Albumentations metadata."""
+        super().__init__("albumentations")
+        self.__version__ = "1.4.99"
+        self.HorizontalFlip = object()
+        self.ShiftScaleRotate = object()
+        self.RandomBrightnessContrast = object()
+        self.Normalize = object()
+        self.VerticalFlip = object()
+        self.RandomResizedCrop = object()
 
 
 class FakeMCPApp:
@@ -168,6 +189,7 @@ def app_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
     """
     monkeypatch.setitem(sys.modules, "timm", FakeTimm())
     monkeypatch.setitem(sys.modules, "segmentation_models_pytorch", FakeSMP())
+    monkeypatch.setitem(sys.modules, "albumentations", FakeAlbumentations())
 
     fastmcp_mod = ModuleType("fastmcp")
     fastmcp_mod.FastMCP = FakeFastMCP
@@ -206,6 +228,7 @@ def check(condition: object, message: str) -> None:
 
 
 HTTP_OK = 200
+HTTP_NOT_FOUND = 404
 
 
 def test_root_healthcheck(client: TestClient) -> None:
@@ -288,6 +311,37 @@ def test_mcp_route_is_present(client: TestClient) -> None:
     check(response.json() == {"mcp": "ok"}, "Unexpected MCP ping payload")
 
 
+def test_augmentations_route_exposes_presets(client: TestClient) -> None:
+    """`/augmentations` should expose baseline Albumentations presets."""
+    response = client.get("/augmentations")
+    check(response.status_code == HTTP_OK, "Expected 200 on /augmentations")
+    payload = response.json()
+    check(payload["library"] == "albumentations", "Unexpected library name")
+    check(payload["version"] == "1.4.99", "Expected fake albumentations version")
+    check("presets" in payload, "Missing presets key in augmentations payload")
+    check(
+        "classification_basic" in payload["presets"],
+        "Missing classification preset",
+    )
+    check("segmentation_basic" in payload["presets"], "Missing segmentation preset")
+
+
+def test_augmentations_validate_preset_success(client: TestClient) -> None:
+    """`/augmentations/<preset>/validate` should confirm valid presets."""
+    response = client.get("/augmentations/classification_basic/validate")
+    check(response.status_code == HTTP_OK, "Expected 200 on preset validation")
+    payload = response.json()
+    check(payload["preset"] == "classification_basic", "Unexpected preset name")
+    check(payload["is_valid"] is True, "Expected classification preset to be valid")
+    check(payload["missing_transforms"] == [], "No transforms should be missing")
+
+
+def test_augmentations_validate_preset_unknown(client: TestClient) -> None:
+    """Unknown preset validation should return 404."""
+    response = client.get("/augmentations/does_not_exist/validate")
+    check(response.status_code == HTTP_NOT_FOUND, "Expected 404 on unknown preset")
+
+
 def test_libraries_versions_prefers_module_dunder_version(client: TestClient) -> None:
     """`/libraries` should expose the fake timm ``__version__``."""
     response = client.get("/libraries")
@@ -304,7 +358,14 @@ def test_libraries_missing_packages_return_none(
     real_import = __import__
 
     def fake_import(name: str, *args: object, **kwargs: object) -> object:
-        if name in {"keras", "tensorflow", "segmentation_models_pytorch", "torch"}:
+        if name in {
+            "albumentations",
+            "keras",
+            "pycaret",
+            "segmentation_models_pytorch",
+            "tensorflow",
+            "torch",
+        }:
             msg = "not installed"
             raise ImportError(msg)
         return real_import(name, *args, **kwargs)
@@ -321,7 +382,9 @@ def test_libraries_missing_packages_return_none(
     ai = response.json()["AI"]
 
     check(ai["timm"] == "9.9.9", "timm version should still resolve")
+    check(ai["albumentations"] is None, "albumentations should be None when missing")
     check(ai["keras"] is None, "keras should be None when missing")
+    check(ai["pycaret"] is None, "pycaret should be None when missing")
     check(ai["tensorflow"] is None, "tensorflow should be None when missing")
     check(ai["torch"] is None, "torch should be None when missing")
     check(
@@ -349,6 +412,23 @@ def test_libraries_handles_unexpected_exception(
     check(response.status_code == HTTP_OK, "Expected 200 on /libraries with error")
     ai = response.json()["AI"]
     check(ai["keras"] is None, "keras should be None on unexpected import error")
+
+
+def test_libraries_exposes_pycaret_when_available(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`/libraries` should include the pycaret version when available."""
+    monkeypatch.setattr(
+        md,
+        "version",
+        lambda package_name: "4.0.0a8" if package_name == "pycaret" else "0.0.0",
+    )
+
+    response = client.get("/libraries")
+    check(response.status_code == HTTP_OK, "Expected 200 on /libraries")
+    ai = response.json()["AI"]
+    check(ai["pycaret"] == "4.0.0a8", "pycaret version should be reported")
 
 
 def test_encoders_list(client: TestClient) -> None:


### PR DESCRIPTION
### Motivation
- Expose baseline Albumentations presets and provide a small service to validate preset transforms against the installed Albumentations package.
- Ensure the AI library registry tracks newly surfaced optional dependencies (`albumentations` and `pycaret`) so the `/libraries` endpoint reports them.

### Description
- Added a new augmentations microservice at `MAGE/api/services/augmentations.py` which provides `/augmentations` (presets and version) and `/augmentations/{preset_name}/validate` endpoints and a service-local `/health` route.
- Mounted the augmentations service and exposed backward-compatible gateway routes by updating `MAGE/api/main.py` to import and register `augmentation_presets`, `validate_preset`, and `augmentations_service` on both the gateway and `/services/augmentations` prefix.
- Updated the AI library registry in `MAGE/api/common.py` to include `albumentations` and `pycaret` mappings.
- Added optional dependencies to `MAGE/pyproject.toml` for `albumentations` and `pycaret`.
- Added unit tests: `MAGE/tests/test_library_registry.py` to assert registry mappings and extended `MAGE/tests/test_main.py` with mocks for a fake `albumentations` module and tests for the new augmentations endpoints and `pycaret` reporting.

### Testing
- Ran the project test suite with `pytest`, including `MAGE/tests/test_main.py` and the new `MAGE/tests/test_library_registry.py` test file.
- The tests exercised the new routes (`/augmentations`, `/augmentations/{preset}/validate`), the updated `/libraries` behavior for missing and present optional deps, and existing API endpoints.
- All automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02445c3cf4832eb691d9888315562b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced augmentation service with REST API endpoints to discover available presets and validate augmentation configurations.
  * Extended AI library registry to include Albumentations and PyCaret integrations.

* **Tests**
  * Added test coverage for new augmentation service endpoints and library registry mappings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Smartappli/AIMER/pull/915)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->